### PR TITLE
Crypto corrections

### DIFF
--- a/DITA/tasks/import-https-server-certificate.dita
+++ b/DITA/tasks/import-https-server-certificate.dita
@@ -91,6 +91,9 @@
         <substeps>
           <substep>
             <cmd>Open a text-mode console with administrative rights.</cmd>
+            <info>If <ph keyref="product"/> has been installed in a user's home directory and
+              includes a bundled JRE, administrative rights are not required.  In all other cases
+              administrative rights will be required.</info>
           </substep>
           <substep>
             <cmd>Go to the <filepath>lib/security</filepath> directory of the JRE running <ph

--- a/DITA/tasks/import-https-server-certificate.dita
+++ b/DITA/tasks/import-https-server-certificate.dita
@@ -2,103 +2,97 @@
 <!DOCTYPE task
   PUBLIC "-//OASIS//DTD DITA Task//EN" "http://docs.oasis-open.org/dita/v1.1/OS/dtd/task.dtd">
 <task id="import-https-server-certificate">
-    <title>Troubleshooting HTTPS</title>
-    <taskbody>
+  <title>Troubleshooting HTTPS</title>
+  <taskbody>
     <context>
       <p>When <ph keyref="product"/> cannot connect to an HTTPS-capable server, most likely there is
-        no certificate set in the <term>Java Runtime Environment (JRE)</term> that <ph keyref="product"/> runs into.
-        The following procedure describes how to:<ul id="ul_4r3_mhr_kf">
+        no certificate set in the <term>Java Runtime Environment (JRE)</term> that <ph
+          keyref="product"/> runs into. The following procedure describes how to:<ul
+          id="ul_4r3_mhr_kf">
           <li>Export a certificate to a local file using any HTTPS-capable Web browser (for example
             Internet Explorer).</li>
           <li>Import the certificate file into the JRE using the <keyword>keytool</keyword> tool
             that comes bundled with <ph keyref="product"/>.</li>
         </ul></p>
     </context>
-        <steps>
-            <step>
-                <cmd>Export the certificate into a local file</cmd>
-                <substeps>
-                    <substep>
-                        <cmd>Point your HTTPS-aware Web browser to the repository URL. </cmd>
-                        <stepresult>
-                            <p>If this is your first visit to the repository it will be displayed a
-                                security alert stating that the security certificate presented by
-                                the server is not trusted.</p>
-                            <fig>
-                                <title>Security alert - untrusted certificate</title>
-                                <image href="../img/sa_security_alert.png"/>
-                            </fig>
-                        </stepresult>
-                    </substep>
-                    <substep>
-                        <cmd>Go to menu <menucascade>
-                                <uicontrol>Tools</uicontrol>
-                                <uicontrol>Internet Options</uicontrol>
-                            </menucascade>.</cmd>
-                        <stepresult><uicontrol>Internet Options</uicontrol> dialog box is
-              opened.</stepresult>
-                    </substep>
-                    <substep>
-                        <cmd>Select <uicontrol>Security</uicontrol> tab.</cmd>
-                    </substep>
-                    <substep>
-                        <cmd>Select <uicontrol>Trusted sites</uicontrol> icon.</cmd>
-                    </substep>
-                    <substep>
-                        <cmd>Press <uicontrol>Sites</uicontrol> button.</cmd>
-                        <stepresult>This will open <uicontrol>Trusted sites</uicontrol> dialog
-              box.</stepresult>
-                    </substep>
-                    <substep>
-                        <cmd>Add repository URL to <uicontrol>Websites</uicontrol> list.</cmd>
-                    </substep>
-                    <substep>
+    <steps>
+      <step>
+        <cmd>Export the certificate into a local file</cmd>
+        <substeps>
+          <substep>
+            <cmd>Point your HTTPS-aware Web browser to the repository URL. </cmd>
+            <stepresult>
+              <p>If this is your first visit to the repository it will be displayed a security alert
+                stating that the security certificate presented by the server is not trusted.</p>
+              <fig>
+                <title>Security alert - untrusted certificate</title>
+                <image href="../img/sa_security_alert.png"/>
+              </fig>
+            </stepresult>
+          </substep>
+          <substep>
+            <cmd>Go to menu <menucascade>
+                <uicontrol>Tools</uicontrol>
+                <uicontrol>Internet Options</uicontrol>
+              </menucascade>.</cmd>
+            <stepresult><uicontrol>Internet Options</uicontrol> dialog box is opened.</stepresult>
+          </substep>
+          <substep>
+            <cmd>Select <uicontrol>Security</uicontrol> tab.</cmd>
+          </substep>
+          <substep>
+            <cmd>Select <uicontrol>Trusted sites</uicontrol> icon.</cmd>
+          </substep>
+          <substep>
+            <cmd>Press <uicontrol>Sites</uicontrol> button.</cmd>
+            <stepresult>This will open <uicontrol>Trusted sites</uicontrol> dialog box.</stepresult>
+          </substep>
+          <substep>
+            <cmd>Add repository URL to <uicontrol>Websites</uicontrol> list.</cmd>
+          </substep>
+          <substep>
             <cmd>Close the <uicontrol>Trusted sites</uicontrol> and <uicontrol>Internet
                 Options</uicontrol> dialog boxes.</cmd>
           </substep>
-                    <substep>
-                        <cmd>Try again to connect to the same repository URL in Internet
-                            Explorer.</cmd>
-                        <stepresult>The same error page as above will be displayed.</stepresult>
-                    </substep>
-                    <substep>
-                        <cmd>Select <uicontrol>Continue to this website</uicontrol> option.</cmd>
-                        <stepresult>A clickable area with a red icon and text <uicontrol>Certificate
-                                Error</uicontrol> is added to Internet Explorer address
-                            bar.</stepresult>
-                    </substep>
-                    <substep>
+          <substep>
+            <cmd>Try again to connect to the same repository URL in Internet Explorer.</cmd>
+            <stepresult>The same error page as above will be displayed.</stepresult>
+          </substep>
+          <substep>
+            <cmd>Select <uicontrol>Continue to this website</uicontrol> option.</cmd>
+            <stepresult>A clickable area with a red icon and text <uicontrol>Certificate
+                Error</uicontrol> is added to Internet Explorer address bar.</stepresult>
+          </substep>
+          <substep>
             <cmd>Click the <uicontrol>Certificate Error</uicontrol> area.</cmd>
             <stepresult>A dialog box containing a <uicontrol>View certificates</uicontrol> link is
               displayed.</stepresult>
           </substep>
-                    <substep>
+          <substep>
             <cmd>Click the <uicontrol>View certificates</uicontrol> link.</cmd>
             <stepresult><uicontrol>Certificate</uicontrol> dialog box is displayed.</stepresult>
           </substep>
-                    <substep>
+          <substep>
             <cmd>Select <uicontrol>Details</uicontrol> tab of <uicontrol>Certificate</uicontrol>
               dialog box.</cmd>
           </substep>
-                    <substep>
-                        <cmd>Press <uicontrol>Copy to File</uicontrol> button.</cmd>
-                        <stepresult><uicontrol>Certificate Export Wizard</uicontrol> is
-                            started.</stepresult>
-                    </substep>
-                    <substep>
-                        <cmd>Follow indications of wizard for DER encoded binary X.509 certificate.
-                            Save certificate to local file <filepath>server.cer</filepath>.</cmd>
-                    </substep>
-                </substeps>
-            </step>
-            <step>
-                <cmd>Import the local file into the JRE running <ph
-            keyref="product"/>.</cmd>
-                <substeps>
-                    <substep>
-                        <cmd>Open a text-mode console with administrative rights.</cmd>
-                    </substep>
-                    <substep>
+          <substep>
+            <cmd>Press <uicontrol>Copy to File</uicontrol> button.</cmd>
+            <stepresult><uicontrol>Certificate Export Wizard</uicontrol> is started.</stepresult>
+          </substep>
+          <substep>
+            <cmd>Follow indications of wizard for DER encoded binary X.509 certificate. Save
+              certificate to local file <filepath>server.cer</filepath>.</cmd>
+          </substep>
+        </substeps>
+      </step>
+      <step>
+        <cmd>Import the local file into the JRE running <ph keyref="product"/>.</cmd>
+        <substeps>
+          <substep>
+            <cmd>Open a text-mode console with administrative rights.</cmd>
+          </substep>
+          <substep>
             <cmd>Go to the <filepath>lib/security</filepath> directory of the JRE running <ph
                 keyref="product"/>. You find the home directory of the JRE in the <i>java.home</i>
               property that is displayed in the <uicontrol>About</uicontrol> dialog box (<ph
@@ -110,8 +104,22 @@
               is usually located in <filepath>
                 /System/Library/Java/JavaVirtualMachines/1.6.0.jdk/Contents/Home</filepath>
               directory.</cmd>
+            <info>The Apple Java version 1.6 stores the certificates in
+                <filepath>/System/Library/Java/Support/CoreDeploy.bundle/Contents/Home/lib/security/cacerts</filepath>
+              with a symbolic link pointing to it from
+                <filepath>/System/Library/Java/JavaVirtualMachines/1.6.0.jdk/Contents/Home/lib/security/cacerts</filepath>.
+              A system-wide installation from Oracle utilises the operating system's own certificate
+              store, usually in the <filepath>/etc</filepath> directory or a subdirectory of it. A
+              system-wide installation of the JRE or JDK is installed to
+                <filepath>/Library/Java/JavaVirtualMachines/</filepath> and a good systems
+              administrator will usually add a symbolic link of "current" to point to the latest
+              version in use for consistent paths like
+                <filepath>/Library/Java/JavaVirtualMachines/current/Contents/Home</filepath>. The
+              JRE bundled with <ph keyref="product"/> uses the
+                <filepath>.install4j/jre.bundle/Contents/Home/jre/lib/security/cacerts</filepath>
+              path within its installation directory, which is a file and not a directory.</info>
           </substep>
-                    <substep>
+          <substep>
             <cmd>Run the following command:</cmd>
             <info><screen xml:space="preserve">..\..\bin\keytool -import -trustcacerts -file server.cer -keystore cacerts</screen>The
                 <filepath>server.cer</filepath> file contains the server certificate, created during
@@ -132,13 +140,13 @@
 ..\..\bin\keytool -import -alias myalias2 -trustcacerts -file server2.cer -keystore cacerts </codeblock>
                 </p></note></info>
           </substep>
-                </substeps>
-            </step>
-            <step>
-                <cmd>Restart <ph keyref="product"/>. </cmd>
-            </step>
-        </steps>
-    </taskbody>
+        </substeps>
+      </step>
+      <step>
+        <cmd>Restart <ph keyref="product"/>. </cmd>
+      </step>
+    </steps>
+  </taskbody>
   <related-links>
     <link href="../topics/https-webdav-preferences.dita#https-webdav-preferences"/>
   </related-links>

--- a/DITA/topics/preferences-svn.dita
+++ b/DITA/topics/preferences-svn.dita
@@ -74,14 +74,16 @@
           <li><uicontrol>SSLv3, TLSv1</uicontrol> (default value)</li>
           <li><uicontrol>SSLv3 only</uicontrol></li>
           <li><uicontrol>TLSv1 only</uicontrol></li>
-        </ul><note type="caution">Due to multiple flaws with SSL since April 2014 (e.g. Heartbleed),
-          the majority of web servers no longer support SSLv3 and a number have dropped support for
-          TLSv1.0 in favour of TLSv1.1 and above. This could result in users of Java 1.6 or earlier
-          being unable to connect at all. In this case it may be necessary to configure SVN to
-          connect through a proxy or to utilise an alternative connection protocol such as SSH.
-          Since a standard proxy server will not interfere with SSL or TLS connections; using a
-          proxy will require utilising a SOCKS proxy server or a specialised proxy software package
-          which can override the standard settings (e.g. Privoxy).</note></li>
+        </ul><note type="caution">Due to multiple flaws with SSL since April 2014 (e.g. <xref
+            href="https://en.wikipedia.org/wiki/Heartbleed" format="html" scope="external"
+            >Heartbleed</xref>), the majority of web servers no longer support SSLv3 and a number
+          have dropped support for TLSv1.0 in favour of TLSv1.1 and above. This could result in
+          users of Java 1.6 or earlier being unable to connect at all. In this case it may be
+          necessary to configure SVN to connect through a proxy or to utilise an alternative
+          connection protocol such as SSH. Since a standard proxy server will not interfere with SSL
+          or TLS connections; using a proxy will require utilising a SOCKS proxy server or a
+          specialised proxy software package which can override the standard settings (e.g.
+          Privoxy).</note></li>
       <li><uicontrol>Results Console</uicontrol> - Specifies the maximum number of lines displayed
         in the <uicontrol>Console</uicontrol> view. The default value is 1000.</li>
       <li><uicontrol>Annotations View</uicontrol> - Sets the color used in the editor panel for

--- a/DITA/topics/preferences-svn.dita
+++ b/DITA/topics/preferences-svn.dita
@@ -5,7 +5,9 @@
   <title>SVN Preferences</title>
   <prolog>
     <metadata>
-      <keywords><indexterm>Configure the Application<indexterm>SVN</indexterm></indexterm></keywords>
+      <keywords>
+        <indexterm>Configure the Application<indexterm>SVN</indexterm></indexterm>
+      </keywords>
     </metadata>
   </prolog>
   <body>
@@ -72,7 +74,14 @@
           <li><uicontrol>SSLv3, TLSv1</uicontrol> (default value)</li>
           <li><uicontrol>SSLv3 only</uicontrol></li>
           <li><uicontrol>TLSv1 only</uicontrol></li>
-        </ul></li>
+        </ul><note type="caution">Due to multiple flaws with SSL since the end of 2014, the majority
+          of seb servers no longer support SSLv3 and a number have dropped support for TLSv1.0 in
+          favour of TLSv1.2 and above. This could result in users of Java 1.6 or earlier being
+          unable to connect at all. In this case it may be necessary to configure SVN to connect
+          through a proxy or to utilise an alternative connection protocol such as SSH. Since a
+          standard proxy server will not interfere with SSL or TLS connections; using a proxy will require
+          utilising a SOCKS proxy server or a specialised proxy software package which can override
+          the standard settings (e.g. Privoxy).</note></li>
       <li><uicontrol>Results Console</uicontrol> - Specifies the maximum number of lines displayed
         in the <uicontrol>Console</uicontrol> view. The default value is 1000.</li>
       <li><uicontrol>Annotations View</uicontrol> - Sets the color used in the editor panel for

--- a/DITA/topics/preferences-svn.dita
+++ b/DITA/topics/preferences-svn.dita
@@ -74,14 +74,14 @@
           <li><uicontrol>SSLv3, TLSv1</uicontrol> (default value)</li>
           <li><uicontrol>SSLv3 only</uicontrol></li>
           <li><uicontrol>TLSv1 only</uicontrol></li>
-        </ul><note type="caution">Due to multiple flaws with SSL since the end of 2014, the majority
-          of seb servers no longer support SSLv3 and a number have dropped support for TLSv1.0 in
-          favour of TLSv1.2 and above. This could result in users of Java 1.6 or earlier being
-          unable to connect at all. In this case it may be necessary to configure SVN to connect
-          through a proxy or to utilise an alternative connection protocol such as SSH. Since a
-          standard proxy server will not interfere with SSL or TLS connections; using a proxy will require
-          utilising a SOCKS proxy server or a specialised proxy software package which can override
-          the standard settings (e.g. Privoxy).</note></li>
+        </ul><note type="caution">Due to multiple flaws with SSL since April 2014 (e.g. Heartbleed),
+          the majority of web servers no longer support SSLv3 and a number have dropped support for
+          TLSv1.0 in favour of TLSv1.1 and above. This could result in users of Java 1.6 or earlier
+          being unable to connect at all. In this case it may be necessary to configure SVN to
+          connect through a proxy or to utilise an alternative connection protocol such as SSH.
+          Since a standard proxy server will not interfere with SSL or TLS connections; using a
+          proxy will require utilising a SOCKS proxy server or a specialised proxy software package
+          which can override the standard settings (e.g. Privoxy).</note></li>
       <li><uicontrol>Results Console</uicontrol> - Specifies the maximum number of lines displayed
         in the <uicontrol>Console</uicontrol> view. The default value is 1000.</li>
       <li><uicontrol>Annotations View</uicontrol> - Sets the color used in the editor panel for


### PR DESCRIPTION
Updated details on the OS X paths for JREs and JDKs depending on whether the source is Apple (/System/Library/Java), Sun/Oracle (/Library/Java) or bundled (oxygen/.install4j).

Added a cautionary note to the bit recommending selecting SSLv3 because of Heartbleed.

On a side note, you should remove HttpClient version 3 now that it is EOL.

Clarified when admin access is needed for updating CA certs.
