### PR TITLE
The CSS property is written with a hyphen: http://www.w3schools.com/cssref/pr_text_white-space.asp

### DIFF
--- a/DITA/topics/dg-trim-ws-value-css-extension.dita
+++ b/DITA/topics/dg-trim-ws-value-css-extension.dita
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <topic id="dg-trim-ws-value-css-extension">
-  <title><codeph>whitespace</codeph> Property: <codeph>-oxy-trim-when-ws-only</codeph>
+  <title><codeph>white-space</codeph> Property: <codeph>-oxy-trim-when-ws-only</codeph>
     Value</title>
   <prolog>
     <metadata>
@@ -9,13 +9,13 @@
         <indexterm>CSS extensions<indexterm>Additional CSS
               properties<indexterm>-oxy-trim-when-ws-only property
           value</indexterm></indexterm></indexterm>
-        <indexterm>CSS extensions<indexterm>Additional CSS properties<indexterm>whitespace
+        <indexterm>CSS extensions<indexterm>Additional CSS properties<indexterm>white-space
               property</indexterm></indexterm></indexterm>
       </keywords>
     </metadata>
   </prolog>
   <body>
-    <p><ph keyref="product"/> allows you to set the <codeph>whitespace</codeph> property to
+    <p><ph keyref="product"/> allows you to set the <codeph>white-space</codeph> property to
         <codeph>-oxy-trim-when-ws-only</codeph>, meaning that the leading and trailing whitespaces
       are removed.</p>
   </body>


### PR DESCRIPTION
Typo in CSS property name "white-space"